### PR TITLE
Add graceful connection closure for notify listeners

### DIFF
--- a/packages/meteor-postgres/postgres/serversql.js
+++ b/packages/meteor-postgres/postgres/serversql.js
@@ -1,6 +1,20 @@
 pg = Npm.require('pg'); // Node-Postgres
 var clientHolder = {};
 
+function removeListeningConnections(){
+  for (var key in clientHolder) {
+    clientHolder[key].end();
+  }
+}
+
+process.on('exit', removeListeningConnections);
+_.each(['SIGINT', 'SIGHUP', 'SIGTERM'], function (sig) {
+  process.once(sig, function () {
+    removeListeningConnections();
+    process.kill(process.pid, sig);
+  });
+});
+
 /**
  * @param Collection
  * @constructor


### PR DESCRIPTION
Currently, if you shut down the server (!) OR crash, this package creates hanging postgres connections and there is no way to even get at the clientHolder object to manually close them.

This change follows cleanup.js semantics https://github.com/meteor/meteor/blob/devel/tools/cleanup.js to gracefully clean up resources from listening connections.  I believe this is the easiest and would be even if connections were exposed.
