### PR TITLE
Added maintained meteor-postgres alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-### As Meteor has announced that they will be providing native SQL support in the future, we are no longer maintaining this repo. 
+### As Meteor has announced that they will be providing native SQL support in the future, we are no longer maintaining this repo. But you can find an maintained version [here](https://github.com/storeness/meteor-postgres).
 
 # [Meteor-Postgres](http://www.meteorpostgres.com/)
 


### PR DESCRIPTION
Thanks for your work on meteor-postgres. Upon your work we brought meteor-postgres to the next version with tests and bug fixes and intend to maintain it, until Meteor releases it SQL version. I thought maybe you want to link people to it as long as there is no real alternative yet.
